### PR TITLE
Moved mcast_default_link ipv4 & ipv6 in pico_stack

### DIFF
--- a/include/pico_stack.h
+++ b/include/pico_stack.h
@@ -168,6 +168,10 @@ struct pico_stack {
     uint16_t ipv4_pre_forward_last_proto;
     struct pico_ip4 ipv4_pre_forward_last_src;
     struct pico_ip4 ipv4_pre_forward_last_dst;
+#   ifdef PICO_SUPPORT_MCAST
+    /* Default network interface for multicast transmission */
+    struct pico_ipv4_link *ipv4_mcast_default_link;
+#   endif
 #endif
 
 #ifdef PICO_SUPPORT_IPV6
@@ -184,6 +188,10 @@ struct pico_stack {
 #   ifdef PICO_SUPPORT_IPV6PMTU
     struct pico_tree IPV6PathCache;
     struct pico_ipv6_path_timer ipv6_path_cache_gc_timer;
+#   endif
+#   ifdef PICO_SUPPORT_MCAST
+    /* Default network interface for multicast transmission */
+    struct pico_ipv6_link *ipv6_mcast_default_link;
 #   endif
 #endif
 

--- a/modules/pico_ipv4.h
+++ b/modules/pico_ipv4.h
@@ -154,7 +154,7 @@ void pico_ipv4_unreachable(struct pico_stack *S, struct pico_frame *f, int err);
 
 int pico_ipv4_mcast_join(struct pico_stack *S, struct pico_ip4 *mcast_link, struct pico_ip4 *mcast_group, uint8_t reference_count, uint8_t filter_mode, struct pico_tree *MCASTFilter);
 int pico_ipv4_mcast_leave(struct pico_stack *S, struct pico_ip4 *mcast_link, struct pico_ip4 *mcast_group, uint8_t reference_count, uint8_t filter_mode, struct pico_tree *MCASTFilter);
-struct pico_ipv4_link *pico_ipv4_get_default_mcastlink(void);
+struct pico_ipv4_link *pico_ipv4_get_default_mcastlink(struct pico_stack *S);
 int pico_ipv4_cleanup_links(struct pico_stack *S, struct pico_device *dev);
 
 /* Raw socket support (GPLv2/v3 only) */

--- a/modules/pico_ipv6.h
+++ b/modules/pico_ipv6.h
@@ -202,7 +202,7 @@ void pico_ipv6_router_down(struct pico_stack *S, const struct pico_ip6 *address)
 int pico_ipv6_mcast_join(struct pico_stack *S, struct pico_ip6 *mcast_link, struct pico_ip6 *mcast_group, uint8_t reference_count, uint8_t filter_mode, struct pico_tree *_MCASTFilter);
 int pico_ipv6_mcast_leave(struct pico_stack *S, struct pico_ip6 *mcast_link, struct pico_ip6 *mcast_group, uint8_t reference_count, uint8_t filter_mode, struct pico_tree *_MCASTFilter);
 
-struct pico_ipv6_link *pico_ipv6_get_default_mcastlink(void);
+struct pico_ipv6_link *pico_ipv6_get_default_mcastlink(struct pico_stack *S);
 
 int pico_ipv6_is_null_address(struct pico_ip6 *ip6);
 #endif

--- a/stack/pico_socket_multicast.c
+++ b/stack/pico_socket_multicast.c
@@ -571,7 +571,7 @@ static void *pico_socket_mcast_filter_link_get(struct pico_socket *s)
 
     if( IS_SOCK_IPV4(s)) {
         if (!s->local_addr.ip4.addr)
-            return pico_ipv4_get_default_mcastlink();
+            return pico_ipv4_get_default_mcastlink(s->stack);
 
         return pico_ipv4_link_get(s->stack, &s->local_addr.ip4);
     }
@@ -579,7 +579,7 @@ static void *pico_socket_mcast_filter_link_get(struct pico_socket *s)
 #ifdef PICO_SUPPORT_IPV6
     else if( IS_SOCK_IPV6(s)) {
         if (pico_ipv6_is_null_address(&s->local_addr.ip6))
-            return pico_ipv6_get_default_mcastlink();
+            return pico_ipv6_get_default_mcastlink(s->stack);
 
         return pico_ipv6_link_get(s->stack, &s->local_addr.ip6);
     }
@@ -612,7 +612,7 @@ int pico_socket_mcast_filter(struct pico_socket *s, union pico_address *mcast_gr
 static struct pico_ipv4_link *get_mcast_link(struct pico_stack *S, union pico_address *a)
 {
     if (!a->ip4.addr)
-        return pico_ipv4_get_default_mcastlink();
+        return pico_ipv4_get_default_mcastlink(S);
 
     return pico_ipv4_link_get(S, &a->ip4);
 }
@@ -621,7 +621,7 @@ static struct pico_ipv6_link *get_mcast_link_ipv6(struct pico_stack *S, union pi
 {
 
     if (pico_ipv6_is_null_address(&a->ip6)) {
-        return pico_ipv6_get_default_mcastlink();
+        return pico_ipv6_get_default_mcastlink(S);
     }
 
     return pico_ipv6_link_get(S, &a->ip6);


### PR DESCRIPTION
ipv4_mcast_default_link and ipv6_mcast_default_link are now members of the struct pico_stack.
pico_ipv*_get_default_mcastlink now takes the stack as additional parameter.