### PR TITLE
Various fixes on size calculation

### DIFF
--- a/modules/pico_ipfilter.c
+++ b/modules/pico_ipfilter.c
@@ -461,18 +461,18 @@ int ipfilter(struct pico_frame *f)
     temp.fdev = f->dev;
     temp.out_addr = ipv4_hdr->dst.addr;
     temp.in_addr = ipv4_hdr->src.addr;
-    if ((ipv4_hdr->proto == PICO_PROTO_TCP) || (ipv4_hdr->proto == PICO_PROTO_UDP)) {
-        trans = (struct pico_trans *) f->transport_hdr;
-        temp.out_port = short_be(trans->dport);
-        temp.in_port = short_be(trans->sport);
+    if ((f->transport_hdr + sizeof(struct pico_trans)) <= (f->buffer + f->buffer_len)) {
+        if ((ipv4_hdr->proto == PICO_PROTO_TCP) || (ipv4_hdr->proto == PICO_PROTO_UDP)) {
+                trans = (struct pico_trans *) f->transport_hdr;
+                temp.out_port = short_be(trans->dport);
+                temp.in_port = short_be(trans->sport);
+        } else if(ipv4_hdr->proto == PICO_PROTO_ICMP4) {
+            icmp_hdr = (struct pico_icmp4_hdr *) f->transport_hdr;
+            if(icmp_hdr->type == PICO_ICMP_UNREACH && icmp_hdr->code == PICO_ICMP_UNREACH_FILTER_PROHIB)
+                return 0;
+        }
+        temp.proto = ipv4_hdr->proto;
     }
-    else if(ipv4_hdr->proto == PICO_PROTO_ICMP4) {
-        icmp_hdr = (struct pico_icmp4_hdr *) f->transport_hdr;
-        if(icmp_hdr->type == PICO_ICMP_UNREACH && icmp_hdr->code == PICO_ICMP_UNREACH_FILTER_PROHIB)
-            return 0;
-    }
-
-    temp.proto = ipv4_hdr->proto;
     temp.priority = f->priority;
     temp.tos = ipv4_hdr->tos;
     return ipfilter_apply_filter(f, &temp);

--- a/modules/pico_ipv4.c
+++ b/modules/pico_ipv4.c
@@ -668,6 +668,11 @@ static int pico_ipv4_process_in(struct pico_stack *S, struct pico_protocol *self
     f->transport_hdr = ((uint8_t *)f->net_hdr) + PICO_SIZE_IP4HDR + option_len;
     f->transport_len = (uint16_t)(short_be(hdr->len) - PICO_SIZE_IP4HDR - option_len);
     f->net_len = (uint16_t)(PICO_SIZE_IP4HDR + option_len);
+
+    if ((f->net_hdr + f->net_len) > (f->buffer + f->buffer_len)) {
+        pico_frame_discard(f);
+        return 0;
+    }
 #if defined(PICO_SUPPORT_IPV4FRAG) || defined(PICO_SUPPORT_IPV6FRAG)
     f->frag = short_be(hdr->frag);
 #endif

--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -868,6 +868,9 @@ static inline void tcp_parse_option_mss(struct pico_socket_tcp *t, uint8_t len, 
     if (tcpopt_len_check(idx, len, PICO_TCPOPTLEN_MSS) < 0)
         return;
 
+    if ((*idx + PICO_TCPOPTLEN_MSS) > len)
+        return;
+
     t->mss_ok = 1;
     mss = short_from(opt + *idx);
     *idx += (uint32_t)sizeof(uint16_t);
@@ -896,6 +899,10 @@ static int tcp_parse_options(struct pico_frame *f)
     uint8_t *opt = f->transport_hdr + PICO_SIZE_TCPHDR;
     uint32_t i = 0;
     f->timestamp = 0;
+
+    if (f->buffer + f->buffer_len > f->transport_hdr + f->transport_len)
+        return -1;
+
     while (i < (f->transport_len - PICO_SIZE_TCPHDR)) {
         uint8_t type =  opt[i++];
         uint8_t len;

--- a/modules/pico_tcp.h
+++ b/modules/pico_tcp.h
@@ -55,6 +55,7 @@ PACKED_STRUCT_DEF tcp_pseudo_hdr_ipv4
 #define PICO_TCPHDR_SIZE 20
 #define PICO_SIZE_TCPOPT_SYN 20
 #define PICO_SIZE_TCPHDR (uint32_t)(sizeof(struct pico_tcp_hdr))
+#define PICO_TCP_MIN_MSS (64 - PICO_SIZE_TCPHDR)
 
 /* TCP options */
 #define PICO_TCP_OPTION_END         0x00


### PR DESCRIPTION
- TCP: Fixed MSS size calculation, set lower MSS bound
- TCP: Check options size before parsing MSS field
- ipfilter: Check transport layer size before dereferencing port numbers
- IPv4: Check transport layer size before calculating checksum