### PR TITLE
MLD fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,9 @@ endif
 ifneq ($(MCAST),0)
   include rules/mcast.mk
   include rules/igmp.mk
-  include rules/mld.mk
+  ifneq ($(MLD),0)
+     include rules/mld.mk
+  endif
 endif
 ifneq ($(NAT),0)
   include rules/nat.mk

--- a/modules/pico_igmp.c
+++ b/modules/pico_igmp.c
@@ -367,6 +367,8 @@ static int pico_igmp_timer_is_running(struct igmp_timer *t)
     test.type = t->type;
     test.mcast_link = t->mcast_link;
     test.mcast_group = t->mcast_group;
+    if (!t->stack)
+        return 0;
     timer = pico_tree_findKey(&t->stack->IGMPTimers, &test);
     if (timer)
         return 1;

--- a/modules/pico_mld.c
+++ b/modules/pico_mld.c
@@ -1173,7 +1173,7 @@ uint16_t pico_mld_checksum(struct pico_frame *f)
     IGNORE_PARAMETER(f);
     return 0;
 }
-int pico_mld_process_in(struct pico_frame *f)
+int pico_mld_process_in(struct pico_stack *S, struct pico_frame *f)
 {
     IGNORE_PARAMETER(f);
     return -1;


### PR DESCRIPTION
Fixes to properly exclude MLD module + NULL pointer dereference in IGMP timer check