### PR TITLE
drop PICO_IDLE()

### DIFF
--- a/docs/user_manual/chap_api_tftp.tex
+++ b/docs/user_manual/chap_api_tftp.tex
@@ -810,7 +810,7 @@ This function returns the number of received bytes of payload (0 included) if su
 \subsection*{Example}
 \begin{verbatim}
 for(;left; left -= countdown) {
-    usleep(2000); //PICO_IDLE();
+    usleep(2000);
     pico_stack_tick();
     if (countdown)
         continue;
@@ -876,7 +876,7 @@ This function returns the number of transmitted payload data (len) if succeeds. 
 \subsection*{Example}
 \begin{verbatim}
 for(;left; left -= countdown) {
-    usleep(2000); //PICO_IDLE();
+    usleep(2000);
     pico_stack_tick();
     if (countdown)
         continue;

--- a/include/arch/pico_arm9.h
+++ b/include/arch/pico_arm9.h
@@ -26,10 +26,3 @@ static inline unsigned long PICO_TIME_MS(void)
 {
     return __str9_tick;
 }
-
-static inline void PICO_IDLE(void)
-{
-    unsigned long tick_now = __str9_tick;
-    while(tick_now == __str9_tick) ;
-}
-

--- a/include/arch/pico_atsamd21j18.h
+++ b/include/arch/pico_atsamd21j18.h
@@ -52,10 +52,3 @@ static inline unsigned long PICO_TIME_MS(void)
 {
     return sam_tick;
 }
-
-static inline void PICO_IDLE(void)
-{
-    unsigned long tick_now = sam_tick;
-    while(tick_now == sam_tick) ;
-}
-

--- a/include/arch/pico_avr.h
+++ b/include/arch/pico_avr.h
@@ -30,10 +30,3 @@ static inline unsigned long PICO_TIME_MS(void)
 {
     return __avr_tick;
 }
-
-static inline void PICO_IDLE(void)
-{
-    unsigned long tick_now = __avr_tick;
-    while(tick_now == __avr_tick) ;
-}
-

--- a/include/arch/pico_dos.h
+++ b/include/arch/pico_dos.h
@@ -35,10 +35,4 @@ static inline unsigned long PICO_TIME(void)
     return (PICO_TIME_MS() / 1000);
 }
 
-static inline void PICO_IDLE(void)
-{
-    union REGS regs;
-    int86(0x28, &regs, &regs); /* DOS 2+ IDLE INTERRUPT */
-}
-
 #endif /* PICO_SUPPORT_DOS_WATCOM */

--- a/include/arch/pico_esp8266.h
+++ b/include/arch/pico_esp8266.h
@@ -48,11 +48,4 @@ static inline pico_time PICO_TIME(void)
     return PICO_TIME_MS() / 1000;
 }
 
-static inline void PICO_IDLE(void)
-{
-    uint32_t now = esp_tick;
-    while (now == esp_tick)
-        ;
-}
-
 #endif

--- a/include/arch/pico_generic_gcc.h
+++ b/include/arch/pico_generic_gcc.h
@@ -68,12 +68,6 @@ static inline pico_time PICO_TIME()
     #endif
 }
 
-static inline void PICO_IDLE(void)
-{
-    pico_time now = PICO_TIME_MS();
-    while(now == PICO_TIME_MS()) ;
-}
-
 #else /* NO RTOS SUPPORT */
 
     #ifdef MEM_MEAS
@@ -103,12 +97,6 @@ static inline pico_time PICO_TIME_MS(void)
 static inline pico_time PICO_TIME(void)
 {
     return (pico_time)(PICO_TIME_MS() / 1000);
-}
-
-static inline void PICO_IDLE(void)
-{
-    unsigned int now = pico_ms_tick;
-    while(now == pico_ms_tick) ;
 }
 
 #endif /* IFNDEF RTOS */

--- a/include/arch/pico_linux.h
+++ b/include/arch/pico_linux.h
@@ -22,12 +22,4 @@ static inline unsigned long PICO_TIME_MS(void)
     return (unsigned long)jiffies_to_msecs(jiffies);
 }
 
-static inline void PICO_IDLE(void)
-{
-    unsigned long now = jiffies;
-    while (now == jiffies) {
-        ;
-    }
-}
-
 #endif

--- a/include/arch/pico_mbed.h
+++ b/include/arch/pico_mbed.h
@@ -163,10 +163,6 @@ static inline pico_time PICO_TIME_MS(void)
   #endif
 }
 
-static inline void PICO_IDLE(void)
-{
-    /* TODO needs implementation */
-}
 /*
    static inline void PICO_DEBUG(const char * formatter, ... )
    {

--- a/include/arch/pico_msp430.h
+++ b/include/arch/pico_msp430.h
@@ -19,7 +19,6 @@ extern void free(void *);
 
 #define PICO_TIME() msp430_time_s()
 #define PICO_TIME_MS() msp430_time_ms()
-#define PICO_IDLE() do {} while(0)
 
 #define pico_free(x) free(x)
 

--- a/include/arch/pico_none.h
+++ b/include/arch/pico_none.h
@@ -16,7 +16,6 @@
 #define pico_free(x) do {} while(0)
 #define PICO_TIME() 666
 #define PICO_TIME_MS() 666000
-#define PICO_IDLE() do {} while(0)
 
 #endif  /* PICO_SUPPORT_ARCHNONE */
 

--- a/include/arch/pico_pic24.h
+++ b/include/arch/pico_pic24.h
@@ -84,17 +84,4 @@ static inline unsigned long PICO_TIME_MS(void)
     return tick;
 }
 
-static inline void PICO_IDLE(void)
-{
-    unsigned long tick_now;
-    /* Disable timer interrupts */
-    TIMBASE_INT_E = 0;
-    tick_now = (unsigned long)pico_tick;
-    /* Enable timer interrupts */
-    TIMBASE_INT_E = 1;
-    /* Doesn't matter that this call isn't interrupt safe, */
-    /* we just check for the value to change */
-    while(tick_now == __pic24_tick) ;
-}
-
 #endif

--- a/include/arch/pico_pic32.h
+++ b/include/arch/pico_pic32.h
@@ -44,11 +44,5 @@ static inline pico_time PICO_TIME(void)
     return (pico_time)(PICO_TIME_MS() / 1000);
 }
 
-static inline void PICO_IDLE(void)
-{
-    unsigned int now = pico_ms_tick;
-    while(now == pico_ms_tick) ;
-}
-
 #endif  /* PICO_PIC32 */
 

--- a/include/arch/pico_posix.h
+++ b/include/arch/pico_posix.h
@@ -134,10 +134,5 @@ extern int pico_sem_wait(void *sem, int timeout);
 extern void *pico_thread_create(void *(*routine)(void *), void *arg);
 #endif  /* PICO_SUPPORT_THREADING */
 
-static inline void PICO_IDLE(void)
-{
-    usleep(5000);
-}
-
 #endif  /* PICO_SUPPORT_POSIX */
 

--- a/test/pico_faulty.h
+++ b/test/pico_faulty.h
@@ -123,11 +123,6 @@ static inline uint32_t PICO_TIME_MS(void)
   #endif
 }
 
-static inline void PICO_IDLE(void)
-{
-    usleep(5000);
-}
-
 void memory_stats(void);
 
 #endif  /* PICO_SUPPORT_POSIX */

--- a/test/test_tftp_app_client.c
+++ b/test/test_tftp_app_client.c
@@ -59,7 +59,7 @@ void start_rx(struct pico_tftp_session *session, int *synchro, const char *filen
     }
 
     for(; left; left -= countdown) {
-        usleep(2000); /* PICO_IDLE(); */
+        usleep(2000);
         pico_stack_tick();
         if (countdown)
             continue;
@@ -132,7 +132,7 @@ void start_tx(struct pico_tftp_session *session, int *synchro, const char *filen
     }
 
     for(; left; left -= countdown) {
-        usleep(2000); /* PICO_IDLE(); */
+        usleep(2000);
         pico_stack_tick();
         if (countdown)
             continue;


### PR DESCRIPTION
The commit 5c330b4c "Fixed more globals. New API. Fixed most tests." removed the last use of PICO_IDLE().