### PR TITLE
Correct the MSS option size check

### DIFF
--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -868,7 +868,7 @@ static inline void tcp_parse_option_mss(struct pico_socket_tcp *t, uint8_t len, 
     if (tcpopt_len_check(idx, len, PICO_TCPOPTLEN_MSS) < 0)
         return;
 
-    if ((*idx + PICO_TCPOPTLEN_MSS) > len)
+    if ((*idx + PICO_TCPOPTLEN_MSS - 2) > len)
         return;
 
     t->mss_ok = 1;


### PR DESCRIPTION
The length parameter in option counts the total length, not just the length of the data.
https://www.rfc-editor.org/rfc/rfc9293.html#section-3.2-10

This fixed the issues we encountered.