### PR TITLE
Allow compiling with TCP=0, PING=0

### DIFF
--- a/stack/pico_socket.c
+++ b/stack/pico_socket.c
@@ -1635,9 +1635,11 @@ int pico_socket_fionread(struct pico_socket *s)
         return f->payload_len;
     }
 #endif
+#ifdef PICO_SUPPORT_TCP
     else if (PROTO(s) == PICO_PROTO_TCP) {
         return pico_tcp_queue_in_size(s);
     }
+#endif
     return 0;
 }
 

--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -896,7 +896,9 @@ int MOCKABLE pico_stack_init(struct pico_stack **S)
 #ifdef PICO_SUPPORT_ICMP4
     pico_protocol_init(*S, &pico_proto_icmp4);
     ATTACH_QUEUES(*S, icmp4, pico_proto_icmp4);
+#ifdef PICO_SUPPORT_PING
     EMPTY_TREE((*S)->Pings, pico_icmp4_cookie_compare);
+#endif
     EMPTY_TREE((*S)->ICMP4Sockets, icmp4_socket_cmp);
 #endif
 


### PR DESCRIPTION
Add missing guards around non-existing symbols when those modules are compiled out.

Fixes builds with TCP=0, PING=0.