### PR TITLE
Fix compiler warnings about discarded qualifiers

### DIFF
--- a/modules/pico_icmp4.c
+++ b/modules/pico_icmp4.c
@@ -127,7 +127,7 @@ int pico_socket_icmp4_recvfrom(struct pico_socket *s, void *buf, int len, void *
     return len;
 }
 
-int pico_socket_icmp4_sendto_check(struct pico_socket *s, void *buf, int len, void *dst, uint16_t remote_port)
+int pico_socket_icmp4_sendto_check(struct pico_socket *s, const void *buf, int len, void *dst, uint16_t remote_port)
 {
     struct pico_icmp4_hdr *hdr;
     struct pico_socket_icmp4 *i4 = (struct pico_socket_icmp4 *)s;

--- a/modules/pico_icmp4.h
+++ b/modules/pico_icmp4.h
@@ -169,7 +169,7 @@ int pico_icmp4_ping_abort(struct pico_stack *S, int id);
 
 struct pico_socket *pico_socket_icmp4_open(struct pico_stack *S);
 int pico_socket_icmp4_close(struct pico_socket *arg);
-int pico_socket_icmp4_sendto_check(struct pico_socket *s, void *buf, int len, void *dst, uint16_t remote_port);
+int pico_socket_icmp4_sendto_check(struct pico_socket *s, const void *buf, int len, void *dst, uint16_t remote_port);
 int pico_socket_icmp4_recvfrom(struct pico_socket *s, void *buf, int len, void *orig, uint16_t *remote_port);
 int pico_socket_icmp4_bind(struct pico_socket *s, void *addr, uint16_t port);
 

--- a/modules/pico_ipv4.c
+++ b/modules/pico_ipv4.c
@@ -513,7 +513,7 @@ static int pico_socket_ipv4_process_out(struct pico_socket *s, struct pico_frame
     return -1;
 }
 
-int pico_socket_ipv4_sendto(struct pico_socket *s, void *buf, uint32_t len, void *dst)
+int pico_socket_ipv4_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *dst)
 {
     struct pico_frame *f;
     struct pico_socket_ipv4 *s4 = (struct pico_socket_ipv4 *)s;

--- a/modules/pico_ipv4.h
+++ b/modules/pico_ipv4.h
@@ -161,7 +161,7 @@ int pico_ipv4_cleanup_links(struct pico_stack *S, struct pico_device *dev);
 struct pico_socket_ipv4;
 struct pico_socket *pico_socket_ipv4_open(struct pico_stack *S, uint16_t proto);
 int pico_socket_ipv4_recvfrom(struct pico_socket *s, void *buf, uint32_t len, void *orig, uint16_t *remote_port);
-int pico_socket_ipv4_sendto(struct pico_socket *s, void *buf, uint32_t len, void *dst);
+int pico_socket_ipv4_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *dst);
 int pico_setsockopt_ipv4(struct pico_socket *s, int option, void *value);
 int pico_getsockopt_ipv4(struct pico_socket *s, int option, void *value);
 

--- a/modules/pico_socket_ll.c
+++ b/modules/pico_socket_ll.c
@@ -190,7 +190,7 @@ int pico_socket_ll_recvfrom(struct pico_socket *s, void *buf, uint32_t len, void
     return (int)len;
 }
 
-int pico_socket_ll_sendto(struct pico_socket *s, void *buf, uint32_t len, void *_dst)
+int pico_socket_ll_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *_dst)
 {
     struct pico_frame *f;
     struct pico_ll *dst = (struct pico_ll *)_dst;

--- a/modules/pico_socket_ll.h
+++ b/modules/pico_socket_ll.h
@@ -49,7 +49,7 @@ int pico_socket_ll_process_in(struct pico_stack *S, struct pico_protocol *self, 
 struct pico_frame *pico_ll_frame_alloc(struct pico_stack *S, struct pico_protocol *self, struct pico_device *dev, uint16_t size);
 struct pico_socket *pico_socket_ll_open(struct pico_stack *S, uint16_t proto);
 int pico_socket_ll_recvfrom(struct pico_socket *s, void *buf, uint32_t len, void *orig);
-int pico_socket_ll_sendto(struct pico_socket *s, void *buf, uint32_t len, void *dst);
+int pico_socket_ll_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *dst);
 int pico_setsockopt_ll(struct pico_socket *s, int option, void *value);
 int pico_getsockopt_ll(struct pico_socket *s, int option, void *value);
 int pico_socket_ll_close(struct pico_socket *arg);


### PR DESCRIPTION
With GCC 15.1
```
stack/pico_socket.c: In function ‘pico_socket_sendto_extended’:
stack/pico_socket.c:1473:47: warning: passing argument 2 of ‘pico_socket_icmp4_sendto_check’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
 1473 |         if (pico_socket_icmp4_sendto_check(s, buf, len, dst, remote_port) < 0)
      |                                               ^~~
In file included from stack/pico_socket.c:36:
modules/pico_icmp4.h:172:65: note: expected ‘void *’ but argument is of type ‘const void *’
  172 | int pico_socket_icmp4_sendto_check(struct pico_socket *s, void *buf, int len, void *dst, uint16_t remote_port);
      |                                                           ~~~~~~^~~
```