### PR TITLE
Remove deleted pico_protocols_loop function

### DIFF
--- a/include/pico_protocol.h
+++ b/include/pico_protocol.h
@@ -126,7 +126,6 @@ struct pico_protocol {
     uint16_t (*get_mtu)(struct pico_stack *S, struct pico_protocol *self);
 };
 
-int pico_protocols_loop(int loop_score);
 int pico_protocol_scheduler_init(struct pico_stack *S);
 void pico_protocol_init(struct pico_stack *S, struct pico_protocol *p);
 

--- a/test/unit/modunit_pico_protocol.c
+++ b/test/unit/modunit_pico_protocol.c
@@ -166,8 +166,6 @@ START_TEST(tc_pico_protocol_generic_loop)
     ret = pico_protocol_generic_loop(&rr, 0, PICO_LOOP_DIR_IN);
 
     fail_if(ret != 0);
-
-    pico_protocols_loop(0);
 }
 END_TEST
 


### PR DESCRIPTION
The function declaration does not exist anymore in `stack/pico_protocol.c`