### PR TITLE
Add missing PICO_TREE_DECLARE for unit tests

### DIFF
--- a/test/unit/modunit_pico_fragments.c
+++ b/test/unit/modunit_pico_fragments.c
@@ -182,6 +182,13 @@ START_TEST(tc_pico_fragments_complete)
 }
 END_TEST
 
+#define PICO_TREE_DECLARE(name, compareFunction) \
+    struct pico_tree name = \
+    { \
+        &LEAF, \
+        compareFunction \
+    }
+
 START_TEST(tc_pico_fragments_empty_tree)
 {
     PICO_TREE_DECLARE(tree, pico_ipv4_frag_compare);

--- a/test/unit/modunit_pico_igmp.c
+++ b/test/unit/modunit_pico_igmp.c
@@ -47,6 +47,12 @@ static int mcast_sources_cmp(void *ka, void *kb)
 
     return 0;
 }
+#define PICO_TREE_DECLARE(name, compareFunction) \
+    struct pico_tree name = \
+    { \
+        &LEAF, \
+        compareFunction \
+    }
 static PICO_TREE_DECLARE(_MCASTFilter, mcast_filter_cmp);
 START_TEST(tc_pico_igmp_report_expired)
 {

--- a/test/unit/modunit_pico_mld.c
+++ b/test/unit/modunit_pico_mld.c
@@ -34,6 +34,12 @@ static int mcast_sources_cmp_ipv6(void *ka, void *kb)
     union pico_address *a = ka, *b = kb;
     return memcmp(&a->ip6, &b->ip6, sizeof(struct pico_ip6));
 }
+#define PICO_TREE_DECLARE(name, compareFunction) \
+    struct pico_tree name = \
+    { \
+        &LEAF, \
+        compareFunction \
+    }
 static PICO_TREE_DECLARE(_MCASTFilter, mcast_filter_cmp_ipv6);
 
 START_TEST(tc_pico_mld_fill_hopbyhop)

--- a/test/unit/unit_rbtree.c
+++ b/test/unit/unit_rbtree.c
@@ -11,6 +11,12 @@ int compare(void *a, void *b)
     return ((elem *)a)->value - ((elem *)b)->value;
 }
 
+#define PICO_TREE_DECLARE(name, compareFunction) \
+    struct pico_tree name = \
+    { \
+        &LEAF, \
+        compareFunction \
+    }
 static PICO_TREE_DECLARE(test_tree, compare);
 static PICO_TREE_DECLARE(test_tree2, compare);
 #define RBTEST_SIZE 20000


### PR DESCRIPTION
The macro `PICO_TREE_DECLARE` has been removed with commit c9285b3501c2e3db81ae4b961e2ac73272bdb5a5 but it is still necessary to have it for unit tests