### PR TITLE
Fix pico_strncasecmp to return 0 on equal strings

### DIFF
--- a/modules/pico_strings.c
+++ b/modules/pico_strings.c
@@ -53,7 +53,7 @@ int pico_strncasecmp(const char *const str1, const char *const str2, size_t n)
         if ((!ch1) && (!ch2))
             return 0;
     }
-    return 1;
+    return 0;
 }
 
 size_t pico_strnlen(const char *str, size_t n)


### PR DESCRIPTION
Without this change, `pico_strncasecmp("unit","UNIT",4)` (from the `tc_pico_strncasecmp` unit test)  returns 1 while it should return 0