### PR TITLE
Fix compiler warning regarding pico_schedule_job

### DIFF
--- a/include/pico_jobs.h
+++ b/include/pico_jobs.h
@@ -22,11 +22,10 @@
  *********************************************************************/
 #ifndef PICO_JOBS_H
 #define PICO_JOBS_H
-#include "pico_defines.h"
+
 #include "pico_stack.h"
 
 void pico_schedule_job(struct pico_stack *S, void (*exe)(struct pico_stack *, void*), void *arg);
 void pico_execute_pending_jobs(struct pico_stack *S);
-
 
 #endif

--- a/stack/pico_jobs.c
+++ b/stack/pico_jobs.c
@@ -21,9 +21,10 @@
  *
  *********************************************************************/
 #include "pico_defines.h"
-#ifdef PICO_SUPPORT_TICKLESS
 #include "pico_jobs.h"
 #include "pico_stack.h"
+
+#ifdef PICO_SUPPORT_TICKLESS
 struct pico_job
 {
     void (*exe)(struct pico_stack *, void *);


### PR DESCRIPTION
```
gcc -c -I/home/runner/work/picotcp/picotcp/build/include -Iinclude -Imodules  -DPICO_COMPILE_TIME=`date +%s`  -DPICO_6LOWPAN_IPHC_ENABLED -DPICO_6LOWPAN_LLS=0 -Wall -W -Wextra -Wshadow -Wcast-qual -Wwrite-strings -Wundef -Wdeclaration-after-statement -Wno-address-of-packed-member -Wconversion -Wcast-align -Wmissing-prototypes -Wno-missing-field-initializers -ggdb -o stack/pico_jobs.o stack/pico_jobs.c
stack/pico_jobs.c:78:31: warning: ‘struct pico_stack’ declared inside parameter list will not be visible outside of this definition or declaration
   78 | void pico_schedule_job(struct pico_stack *S, void (*exe)(struct pico_stack *, void*), void *arg)
      |                               ^~~~~~~~~~
stack/pico_jobs.c:78:6: warning: no previous prototype for ‘pico_schedule_job’ [-Wmissing-prototypes]
   78 | void pico_schedule_job(struct pico_stack *S, void (*exe)(struct pico_stack *, void*), void *arg)
      |      ^~~~~~~~~~~~~~~~~
```