### PR TITLE
Fix parameter names mismatch

### DIFF
--- a/include/pico_frame.h
+++ b/include/pico_frame.h
@@ -125,7 +125,7 @@ int pico_frame_grow_head(struct pico_frame *f, uint32_t size);
 struct pico_frame *pico_frame_alloc_skeleton(uint32_t size, int ext_buffer);
 int pico_frame_skeleton_set_buffer(struct pico_frame *f, void *buf);
 uint16_t pico_checksum(void *inbuf, uint32_t len);
-uint16_t pico_dualbuffer_checksum(void *b1, uint32_t len1, void *b2, uint32_t len2);
+uint16_t pico_dualbuffer_checksum(void *inbuf1, uint32_t len1, void *inbuf2, uint32_t len2);
 
 static inline int pico_is_digit(char c)
 {

--- a/include/pico_socket.h
+++ b/include/pico_socket.h
@@ -221,7 +221,7 @@ int pico_socket_sendto(struct pico_socket *s, const void *buf, int len, void *ds
 int pico_socket_sendto_extended(struct pico_socket *s, const void *buf, const int len,
                                 void *dst, uint16_t remote_port, struct pico_msginfo *msginfo);
 
-int pico_socket_recvfrom(struct pico_socket *s, void *buf, int len, void *orig, uint16_t *local_port);
+int pico_socket_recvfrom(struct pico_socket *s, void *buf, int len, void *orig, uint16_t *remote_port);
 int pico_socket_recvfrom_extended(struct pico_socket *s, void *buf, int len, void *orig,
                                   uint16_t *remote_port, struct pico_msginfo *msginfo);
 
@@ -232,7 +232,7 @@ int pico_socket_bind(struct pico_socket *s, void *local_addr, uint16_t *port);
 int pico_socket_getname(struct pico_socket *s, void *local_addr, uint16_t *port, uint16_t *proto);
 int pico_socket_getpeername(struct pico_socket *s, void *remote_addr, uint16_t *port, uint16_t *proto);
 
-int pico_socket_connect(struct pico_socket *s, const void *srv_addr, uint16_t remote_port);
+int pico_socket_connect(struct pico_socket *s, const void *remote_addr, uint16_t remote_port);
 int pico_socket_listen(struct pico_socket *s, const int backlog);
 struct pico_socket *pico_socket_accept(struct pico_socket *s, void *orig, uint16_t *port);
 int8_t pico_socket_del(struct pico_socket *s);

--- a/modules/pico_dhcp_client.h
+++ b/modules/pico_dhcp_client.h
@@ -34,12 +34,12 @@
 
 struct pico_stack;
 int dhcp_cookies_cmp(void *ka, void *kb);
-int pico_dhcp_initiate_negotiation(struct pico_device *device, void (*callback)(void*cli, int code), uint32_t *xid);
+int pico_dhcp_initiate_negotiation(struct pico_device *dev, void (*cb)(void *dhcpc, int code), uint32_t *uid);
 void *pico_dhcp_get_identifier(struct pico_stack *S, uint32_t xid);
-struct pico_ip4 pico_dhcp_get_address(void *cli);
-struct pico_ip4 pico_dhcp_get_gateway(void *cli);
-struct pico_ip4 pico_dhcp_get_netmask(void *cli);
-struct pico_ip4 pico_dhcp_get_nameserver(void*cli, int index);
+struct pico_ip4 pico_dhcp_get_address(void *dhcpc);
+struct pico_ip4 pico_dhcp_get_gateway(void *dhcpc);
+struct pico_ip4 pico_dhcp_get_netmask(void *dhcpc);
+struct pico_ip4 pico_dhcp_get_nameserver(void*dhcpc, int index);
 int pico_dhcp_client_abort(struct pico_stack *S, uint32_t xid);
 char *pico_dhcp_get_hostname(struct pico_stack *S);
 char *pico_dhcp_get_domain(struct pico_stack *S);

--- a/modules/pico_dhcp_server.h
+++ b/modules/pico_dhcp_server.h
@@ -48,7 +48,7 @@ struct pico_dhcp_server_setting
 int dhcp_settings_cmp(void *ka, void *kb);
 int dhcp_negotiations_cmp(void *ka, void *kb);
 /* required field: IP address of the interface to serve, only IPs of this network will be served. */
-int pico_dhcp_server_initiate(struct pico_dhcp_server_setting *dhcps);
+int pico_dhcp_server_initiate(struct pico_dhcp_server_setting *setting);
 
 /* To destroy an existing DHCP server configuration, running on a given interface */
 int pico_dhcp_server_destroy(struct pico_device *dev);

--- a/modules/pico_dns_client.h
+++ b/modules/pico_dns_client.h
@@ -63,7 +63,7 @@ int pico_dns_client_getaddr(struct pico_stack *S, const char *url, void (*callba
 int pico_dns_client_getname(struct pico_stack *S, const char *ip, void (*callback)(char *url, void *arg), void *arg);
 #ifdef PICO_SUPPORT_IPV6
 int pico_dns_client_getaddr6(struct pico_stack *S, const char *url, void (*callback)(char *, void *), void *arg);
-int pico_dns_client_getname6(struct pico_stack *S, const char *url, void (*callback)(char *, void *), void *arg);
+int pico_dns_client_getname6(struct pico_stack *S, const char *ip, void (*callback)(char *, void *), void *arg);
 #endif
 
 #endif /* _INCLUDE_PICO_DNS_CLIENT */

--- a/modules/pico_dns_common.c
+++ b/modules/pico_dns_common.c
@@ -428,7 +428,7 @@ pico_dns_first_label_length( const char *url )
  *  Mirrors a dotted IPv4-address string.
  *	f.e. 192.168.0.1 => 1.0.168.192
  *
- *  @param ptr
+ *  @param ip
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
 int

--- a/modules/pico_dns_common.h
+++ b/modules/pico_dns_common.h
@@ -241,11 +241,11 @@ pico_dns_first_label_length( const char *url );
  *  Mirrors a dotted IPv4-address string.
  *	f.e. 192.168.0.1 => 1.0.168.192
  *
- *  @param ptr
+ *  @param ip
  *  @return 0 on success, something else on failure.
  * ****************************************************************************/
 int
-pico_dns_mirror_addr( char *ptr );
+pico_dns_mirror_addr( char *ip );
 
 /* ****************************************************************************
  *  Convert an IPv6-address in string-format to a IPv6-address in nibble-format.
@@ -508,8 +508,8 @@ void
 pico_dns_fill_packet_header( struct pico_dns_header *hdr,
                              uint16_t qdcount,
                              uint16_t ancount,
-                             uint16_t authcount,
-                             uint16_t addcount );
+                             uint16_t nscount,
+                             uint16_t arcount );
 
 /* ****************************************************************************
  *  Creates a DNS Query packet with given question and resource records to put

--- a/modules/pico_ipv4.h
+++ b/modules/pico_ipv4.h
@@ -131,8 +131,8 @@ int pico_ipv4_valid_netmask(uint32_t mask);
 int pico_ipv4_is_unicast(uint32_t address);
 int pico_ipv4_is_multicast(uint32_t address);
 int pico_ipv4_is_broadcast(struct pico_stack *S, uint32_t addr);
-int pico_ipv4_is_loopback(uint32_t addr);
-int pico_ipv4_is_valid_src(struct pico_stack *S, uint32_t addr, struct pico_device *dev);
+int pico_ipv4_is_loopback(uint32_t address);
+int pico_ipv4_is_valid_src(struct pico_stack *S, uint32_t address, struct pico_device *dev);
 
 int pico_ipv4_link_add(struct pico_stack *S, struct pico_device *dev, struct pico_ip4 address, struct pico_ip4 netmask);
 int pico_ipv4_link_del(struct pico_stack *S, struct pico_device *dev, struct pico_ip4 address);

--- a/modules/pico_mdns.c
+++ b/modules/pico_mdns.c
@@ -259,7 +259,7 @@ static void
 pico_mdns_send_probe_packet(pico_time now, void *arg );
 
 static int
-pico_mdns_reclaim(struct pico_stack *S,  pico_mdns_rtree record_tree,
+pico_mdns_reclaim(struct pico_stack *S,  pico_mdns_rtree rtree,
                    void (*callback)(pico_mdns_rtree *,
                                     char *,
                                     void *),

--- a/modules/pico_mdns.h
+++ b/modules/pico_mdns.h
@@ -170,7 +170,7 @@ pico_mdns_getrecord(struct pico_stack *S,  const char *url, uint16_t type,
  *  @return 0 When claiming didn't horribly fail.
  * ****************************************************************************/
 int
-pico_mdns_claim(struct pico_stack *S,  pico_mdns_rtree record_tree,
+pico_mdns_claim(struct pico_stack *S,  pico_mdns_rtree rtree,
                  void (*callback)(pico_mdns_rtree *,
                                   char *,
                                   void *),

--- a/modules/pico_socket_ll.h
+++ b/modules/pico_socket_ll.h
@@ -49,7 +49,7 @@ int pico_socket_ll_process_in(struct pico_stack *S, struct pico_protocol *self, 
 struct pico_frame *pico_ll_frame_alloc(struct pico_stack *S, struct pico_protocol *self, struct pico_device *dev, uint16_t size);
 struct pico_socket *pico_socket_ll_open(struct pico_stack *S, uint16_t proto);
 int pico_socket_ll_recvfrom(struct pico_socket *s, void *buf, uint32_t len, void *orig);
-int pico_socket_ll_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *dst);
+int pico_socket_ll_sendto(struct pico_socket *s, const void *buf, uint32_t len, void *_dst);
 int pico_setsockopt_ll(struct pico_socket *s, int option, void *value);
 int pico_getsockopt_ll(struct pico_socket *s, int option, void *value);
 int pico_socket_ll_close(struct pico_socket *arg);

--- a/modules/pico_tcp.c
+++ b/modules/pico_tcp.c
@@ -558,7 +558,7 @@ static int pico_tcp_process_out(struct pico_stack *S, struct pico_protocol *self
     return 0;
 }
 
-int pico_tcp_push(struct pico_stack *S, struct pico_protocol *self, struct pico_frame *data);
+int pico_tcp_push(struct pico_stack *S, struct pico_protocol *self, struct pico_frame *f);
 
 /* Interface: protocol definition */
 struct pico_protocol pico_proto_tcp = {

--- a/modules/pico_tcp.h
+++ b/modules/pico_tcp.h
@@ -109,7 +109,7 @@ uint16_t pico_tcp_overhead(struct pico_socket *s);
 int pico_tcp_output(struct pico_socket *s, int loop_score);
 int pico_tcp_queue_in_is_empty(struct pico_socket *s);
 int pico_tcp_queue_in_size(struct pico_socket *s);
-int pico_tcp_reply_rst(struct pico_stack *S, struct pico_frame *f);
+int pico_tcp_reply_rst(struct pico_stack *S, struct pico_frame *fr);
 void pico_tcp_cleanup_queues(struct pico_socket *sck);
 void pico_tcp_notify_closing(struct pico_socket *sck);
 void pico_tcp_flags_update(struct pico_frame *f, struct pico_socket *s);

--- a/stack/pico_tree.c
+++ b/stack/pico_tree.c
@@ -55,7 +55,7 @@ struct pico_tree_node LEAF = {
  */
 static struct pico_tree_node *create_node(struct pico_tree *tree, void *key, uint8_t allocator);
 static void rotateToLeft(struct pico_tree*tree, struct pico_tree_node*node);
-static void rotateToRight(struct pico_tree*root, struct pico_tree_node*node);
+static void rotateToRight(struct pico_tree*tree, struct pico_tree_node*node);
 static void fix_insert_collisions(struct pico_tree*tree, struct pico_tree_node*node);
 static void fix_delete_collisions(struct pico_tree*tree, struct pico_tree_node *node);
 static void switchNodes(struct pico_tree*tree, struct pico_tree_node*nodeA, struct pico_tree_node*nodeB);


### PR DESCRIPTION
Function declarations and definitions do not use the same parameter names, this PR fixes that