### PR TITLE
Declare pico_zalloc/pico_free for arm9 arch

### DIFF
--- a/include/arch/pico_arm9.h
+++ b/include/arch/pico_arm9.h
@@ -13,8 +13,8 @@
 
 extern volatile uint32_t __str9_tick;
 
-#define pico_native_malloc(x) calloc(x, 1)
-#define pico_native_free(x) free(x)
+#define pico_zalloc(x) calloc(x, 1)
+#define pico_free(x) free(x)
 
 static inline unsigned long PICO_TIME(void)
 {


### PR DESCRIPTION
`pico_zalloc` and `pico_free` are required in each `include/arch/pico_*.h` files. `include/arch/pico_arm9.h` is the only file with the missing macros